### PR TITLE
add startTime argument to scrollToColumn

### DIFF
--- a/Samidare/Classes/SamidareView.swift
+++ b/Samidare/Classes/SamidareView.swift
@@ -387,11 +387,18 @@ public class SamidareView: UIView {
         return reusableCellQueue.create(withReuseIdentifier: identifier) as! T
     }
     
-    public func scrollToColumn(at indexPath: IndexPath, animated: Bool, space: CGFloat = 0) {
+    public func scrollToColumn(at indexPath: IndexPath, animated: Bool, startTime: Date? = nil, space: CGFloat = 0) {
         guard let dataSource = dataSource,
             let layoutData = layoutDataStore.cachedEventScrollViewLayoutData,
             let xPositionOfColumn = layoutData.xPositionOfColumn[indexPath],
             let cell = dataSource.cells(at: indexPath, in: self).first else { return }
+        
+        let scrollStartTime: Date
+        if let startTime = startTime {
+            scrollStartTime = startTime
+        } else {
+            scrollStartTime = cell.event.start
+        }
         
         // control contentOffset so that contentOffset exceed contentSize
         let inset: UIEdgeInsets = eventScrollView.contentInset
@@ -400,7 +407,7 @@ public class SamidareView: UIView {
             = eventScrollView.contentSize.height + inset.bottom > eventScrollView.frame.height
         if isScrollableY {
             let maxContentOffsetY: CGFloat = eventScrollView.contentSize.height - eventScrollView.frame.height + inset.bottom
-            y = layoutData.roundedDistanceOfTimeRangeStart(to: cell.event.start) - inset.top - space
+            y = layoutData.roundedDistanceOfTimeRangeStart(to: scrollStartTime) - inset.top - space
             y = min(y, maxContentOffsetY)
         } else {
             y = -inset.top


### PR DESCRIPTION
scrollToColumnメソッドに、startDate引数を追加しました。

テストコードです。
```
    override func viewDidAppear(_ animated: Bool) {
        super.viewDidAppear(animated)
        
        let formatter = DateFormatter()
        formatter.locale = Locale(identifier: "en_US_POSIX")
        formatter.dateFormat = "yyyy/MM/dd HH:mm"
        let start = formatter.date(from: "2019/08/07 13:00")!
        samidareView.scrollToColumn(at: [0, 0], animated: true, startTime: start, space: 0)
    }
```